### PR TITLE
feat: Add to-do list screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-
+  <uses-permission android:name="android.permission.INTERNET"/>
   <application
       android:allowBackup="true"
       android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/akirachix/todos/MainActivity.kt
+++ b/app/src/main/java/com/akirachix/todos/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.akirachix.todos.screens.TodoScreen
 import com.akirachix.todos.ui.theme.TodosTheme
 
 class MainActivity : ComponentActivity() {
@@ -21,10 +22,11 @@ class MainActivity : ComponentActivity() {
     enableEdgeToEdge()
     setContent {
       TodosTheme {
-        Surface(modifier = Modifier.fillMaxSize().safeContentPadding()) {
-        
-        }
+
+          TodoScreen()
       }
     }
   }
 }
+
+

--- a/app/src/main/java/com/akirachix/todos/api/ApiInterface.kt
+++ b/app/src/main/java/com/akirachix/todos/api/ApiInterface.kt
@@ -1,8 +1,9 @@
 package com.akirachix.todos.api
 import com.akirachix.todos.model.Todo
 import retrofit2.Response
-
 import retrofit2.http.GET
+
+
 interface ApiInterface {
     @GET("/todos")
     suspend fun fetchTodos(): Response<List<Todo>>

--- a/app/src/main/java/com/akirachix/todos/api/ApiInterface.kt
+++ b/app/src/main/java/com/akirachix/todos/api/ApiInterface.kt
@@ -1,0 +1,10 @@
+package com.akirachix.todos.api
+import com.akirachix.todos.model.Todo
+import retrofit2.Response
+
+import retrofit2.http.GET
+interface ApiInterface {
+    @GET("/todos")
+    suspend fun fetchTodos(): Response<List<Todo>>
+
+}

--- a/app/src/main/java/com/akirachix/todos/model/Todo.kt
+++ b/app/src/main/java/com/akirachix/todos/model/Todo.kt
@@ -1,0 +1,8 @@
+package com.akirachix.todos.model
+
+data class Todo(
+    val userId: Int,
+    val id: Int,
+    val title: String,
+    val completed: Boolean
+)

--- a/app/src/main/java/com/akirachix/todos/repository/TodoRepository.kt
+++ b/app/src/main/java/com/akirachix/todos/repository/TodoRepository.kt
@@ -1,0 +1,21 @@
+package com.akirachix.todos.repository
+
+import com.akirachix.todos.api.ApiClient
+import com.akirachix.todos.api.ApiInterface
+import com.akirachix.todos.model.Todo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.Response
+
+class TodoRepository {
+    private val api = ApiClient.buildApiClient(ApiInterface::class.java)
+
+    suspend fun fetchTodos(): Response<List<Todo>> {
+        return withContext(Dispatchers.IO) {
+            api.fetchTodos()
+        }
+    }
+}
+
+
+

--- a/app/src/main/java/com/akirachix/todos/screens/TodoScreen.kt
+++ b/app/src/main/java/com/akirachix/todos/screens/TodoScreen.kt
@@ -1,0 +1,98 @@
+package com.akirachix.todos.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.akirachix.todos.model.Todo
+import com.akirachix.todos.model.UiState
+import com.akirachix.todos.viewModel.TodoViewModel
+
+@Composable
+fun TodoScreen(viewModel: TodoViewModel = viewModel()) {
+    val todos by viewModel.todos.observeAsState(emptyList())
+    val uiState by viewModel.uiState.observeAsState(UiState())
+
+    LaunchedEffect(Unit) {
+        viewModel.fetchTodos()
+    }
+
+    Column(
+        modifier = Modifier
+            .background(Color(0xFFF5F0FC))
+            .padding(16.dp)
+            .fillMaxSize()
+    ) {
+        Text(
+            text = "My Todo List",
+            fontSize = 20.sp,
+            modifier = Modifier.padding(bottom = 12.dp)
+        )
+        when {
+            uiState.isLoading -> {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            uiState.error != null -> {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(text = uiState.error ?: "Unknown error", color = Color.Red)
+                }
+            }
+            todos.isEmpty() -> {
+                Text("No todos available", modifier = Modifier.padding(16.dp))
+            }
+            else -> {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    items(todos) { todo ->
+                        TodoItem(todo)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun TodoItem(todo: Todo) {
+    var checkedState by remember { mutableStateOf(todo.completed) }
+
+    Surface(
+        shape = RoundedCornerShape(8.dp),
+        shadowElevation = 4.dp,
+        tonalElevation = 4.dp,
+        color = Color.LightGray.copy(alpha = 0.3f),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Checkbox(
+                checked = checkedState,
+                onCheckedChange = { checkedState = it },
+                colors = CheckboxDefaults.colors(
+                    checkedColor = Color(0xFF6C1EB8),
+                    uncheckedColor = Color.Gray,
+                    checkmarkColor = Color.White
+                )
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = todo.title,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/akirachix/todos/screens/TodoScreen.kt
+++ b/app/src/main/java/com/akirachix/todos/screens/TodoScreen.kt
@@ -44,7 +44,7 @@ fun TodoScreen(viewModel: TodoViewModel = viewModel()) {
                     CircularProgressIndicator()
                 }
             }
-            uiState.error != null -> {
+            uiState.error?.isNotBlank() == true -> {
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     Text(text = uiState.error ?: "Unknown error", color = Color.Red)
                 }

--- a/app/src/main/java/com/akirachix/todos/viewModel/TodoViewModel.kt
+++ b/app/src/main/java/com/akirachix/todos/viewModel/TodoViewModel.kt
@@ -1,0 +1,36 @@
+package com.akirachix.todos.viewModel
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.akirachix.todos.model.Todo
+import com.akirachix.todos.model.UiState
+import com.akirachix.todos.repository.TodoRepository
+import kotlinx.coroutines.launch
+class TodoViewModel : ViewModel() {
+    private val repository = TodoRepository()
+
+    private val _todos = MutableLiveData<List<Todo>>()
+    val todos: LiveData<List<Todo>> = _todos
+
+    private val _uiState = MutableLiveData<UiState>()
+    val uiState: LiveData<UiState> = _uiState
+
+    fun fetchTodos() {
+        viewModelScope.launch {
+            _uiState.value = UiState(isLoading = true)
+            val response = repository.fetchTodos()
+            if (response.isSuccessful) {
+                val list = response.body()
+                Log.d("TodoViewModel", "Received todos count: ${list?.size}")
+                _todos.postValue(list ?: emptyList())
+                _uiState.value = UiState(success = "Todos loaded", isLoading = false)
+            } else {
+                Log.e("TodoViewModel", "API Error: ${response.errorBody()?.string()}")
+                _uiState.value = UiState(error = response.errorBody()?.string(), isLoading = false)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the Todo List Android app using Kotlin, Retrofit with coroutines, and Jetpack Compose following MVVM architecture. The app fetches todos from the [https://jsonplaceholder.typicode.com/todos](https://jsonplaceholder.typicode.com/todos) API and displays them with the requested UI design.

## Changes
- Retrofit suspend API call with proper response handling  
- Repository using Dispatchers.IO for network calls  
- ViewModel exposing todos and UI state with LiveData  
- Jetpack Compose UI matching the provided todo list design with rounded cards and styled checkboxes  
- Loading indicator and error message handling integrated  

## APK Link
[https://appetize.io/app/your_app_identifier](https://appetize.io/app/b_zzdfx5rwe7mj4du3m357y3cwe4)
